### PR TITLE
Silence output from helm repo add

### DIFF
--- a/docker-images/terraform/fry-helm-in-terraform
+++ b/docker-images/terraform/fry-helm-in-terraform
@@ -6,10 +6,10 @@ helm repo add stable https://kubernetes-charts.storage.googleapis.com/ > /dev/nu
 printenv | grep HELM_REPO_ | while read -r i; do
   repo_name=$(echo ${i} | sed 's#=.*##' | sed 's/HELM_REPO_//')
   repo_link=$(echo ${i} | sed 's/^[^=]*=//g')
-  helm repo add ${repo_name} ${repo_link}
+  helm repo add ${repo_name} ${repo_link} > /dev/null 2>&1
 done
 if [ "${HELM_AUTO_REPO_UPDATE}" = "yes"  ]; then
-  helm repo update
+  helm repo update > /dev/null 2>&1
 fi
 
 printenv | grep HELM_PLUGIN_ | while read -r i; do

--- a/docker-images/terraform/fry-helm-in-terraform
+++ b/docker-images/terraform/fry-helm-in-terraform
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-helm repo add stable https://kubernetes-charts.storage.googleapis.com/
+helm repo add stable https://kubernetes-charts.storage.googleapis.com/ > /dev/null 2>&1
 # Loop thru all env vars starts by HELM_REPO_ and parse repo name and repo link
 # .eg. HELM_REPO_stable=https://kubernetes-charts.storage.googleapis.com/
 printenv | grep HELM_REPO_ | while read -r i; do


### PR DESCRIPTION
The helm command produces output on:
- stderr: If there's no kubeconfig present, it will complain
- stdout: It will notify you that the repo was added
- stdout: It will notify you when helm plugins are installed

This output prepends the otherwise clean output of the `terraform` command that gets executed. That results in problems for things like wrapper scripts, eg
https://github.com/abdennour/eks-training/blob/347deefacd3b55433ae2d09a0a9824c53257c027/run-docker-compose.sh#L4